### PR TITLE
fix generateForeignKeys

### DIFF
--- a/src/Libraries/MigrationGenerator.php
+++ b/src/Libraries/MigrationGenerator.php
@@ -263,7 +263,7 @@ class MigrationGenerator
         $keys = $this->db->getForeignKeyData($table);
         $keyArray = [];
         foreach ($keys as $key)
-            $keyArray[] = "\n\t\t\$this->forge->addForeignKey('$key->column_name','$key->foreign_table_name','$key->foreign_column_name','CASCADE','CASCADE');";
+            $keyArray[] = PHP_EOL . chr(9) . chr(9) . '$this->forge->addForeignKey(\'$key->column_name\',\'$key->foreign_table_name\',\'$key->foreign_column_name\',\'CASCADE\',\'CASCADE\');';
 
         return implode('', array_unique($keyArray));
     }


### PR DESCRIPTION
Fix for:

Array to string conversion

at VENDORPATH/robinncode/db_craft/src/Libraries/MigrationGenerator.php:266

Backtrace:
  1    VENDORPATH/robinncode/db_craft/src/Libraries/MigrationGenerator.php:266
       CodeIgniter\Debug\Exceptions()->errorHandler(2, 'Array to string conversion', '/var/www/html/vendor/robinncode/db_craft/src/Libraries/MigrationGenerator.php', 266)
