### PR TITLE
Add constant for migration table and optimize foreign key generation logic

### DIFF
--- a/src/Libraries/MigrationGenerator.php
+++ b/src/Libraries/MigrationGenerator.php
@@ -262,8 +262,15 @@ class MigrationGenerator
     {
         $keys = $this->db->getForeignKeyData($table);
         $keyArray = [];
-        foreach ($keys as $key)
-            $keyArray[] = "\n\t\t\$this->forge->addForeignKey('$key->column_name','$key->foreign_table_name','$key->foreign_column_name','CASCADE','CASCADE');";
+        foreach ($keys as $key) {
+            $columnName = $key->column_name[0];
+            $foreignColumnName = $key->foreign_column_name[0];
+            $foreignTableName = $key->foreign_table_name;
+            $onDelete = $key->on_delete;
+            $onUpdate = $key->on_update;
+
+            $keyArray[] = "\n\t\t\$this->forge->addForeignKey('$columnName','$foreignTableName','$foreignColumnName','$onDelete','$onUpdate');";
+        }
 
         return implode('', array_unique($keyArray));
     }

--- a/src/Libraries/MigrationGenerator.php
+++ b/src/Libraries/MigrationGenerator.php
@@ -19,6 +19,7 @@ class MigrationGenerator
      * @var array|BaseConnection|string|null
      */
     protected $db = null;
+    const MIGRATION_TABLE = 'migrations';
 
     /**
      * DBHandler constructor.
@@ -44,7 +45,11 @@ class MigrationGenerator
         $tables = $this->getTableNames();
         foreach ($tables as $table) {
             $tableInfo = $this->getTableInfos($table);
-
+            
+            if ($table === self::MIGRATION_TABLE) {
+                            continue;
+            }
+            
             $file = new FileHandler();
             $file->writeTable($table, $tableInfo['attributes'], $tableInfo['keys']);
         }


### PR DESCRIPTION
In this commit, several improvements were made to the MigrationGenerator.php file. 
Firstly, changes in generateAllMigration() prevent migration of 'migrations' table as its created automatically during migration process.

Additionally, the logic for generating foreign keys was fixed as the column_name and foreign_column_name are returned as arrays so we should get the first element from that array.