### PR TITLE
Foreign key check for seeder

### DIFF
--- a/src/Templates/seeder.txt
+++ b/src/Templates/seeder.txt
@@ -27,7 +27,7 @@ class {name} extends Seeder
 
         //Using Query Builder Class ...
         try {
-        $this->db->table('{table}')->insertBatch(${table});
+            $this->db->table('{table}')->insertBatch(${table});
         } catch (ReflectionException $e) {
             throw new ReflectionException($e->getMessage());
         }

--- a/src/Templates/seeder.txt
+++ b/src/Templates/seeder.txt
@@ -19,9 +19,12 @@ class {name} extends Seeder
      */
     public function run(): void
     {
+        // disable foreign key check ...
+        $this->db->disableForeignKeyChecks();
+
         // Table Data ...
         {seeder}
-
+        
         // Cleaning up the table before seeding ...
         $this->db->table('{table}')->truncate();
 
@@ -31,5 +34,8 @@ class {name} extends Seeder
         } catch (ReflectionException $e) {
             throw new ReflectionException($e->getMessage());
         }
+
+        //enable foreign key check ...
+        $this->db->enableForeignKeyChecks();
     }
 }


### PR DESCRIPTION
Hello,

Thank you very much for your work and the helpful class! Everything is working well, except that when I try to seed a table with a foreign key, the seed fails due to the foreign key constraints.

I made a slight modification to the seed template to include the functionality to disable and re-enable foreign key checks, similar to how migrations work.

It might be a good idea to make this an optional parameter for both commands.